### PR TITLE
Fix play time time numbers in the save menu

### DIFF
--- a/src/start_menu.c
+++ b/src/start_menu.c
@@ -1414,7 +1414,7 @@ static void ShowSaveInfoWindow(void)
     yOffset += 16;
     AddTextPrinterParameterized(sSaveInfoWindowId, 2, gText_SavingTime, 0, yOffset, 0xFF, NULL);
     BufferSaveMenuText(SAVE_MENU_PLAY_TIME, gStringVar4, color);
-    xOffset = GetStringRightAlignXOffset(1, gStringVar4, 0x70);
+    xOffset = GetStringRightAlignXOffset(1, gStringVar4, 0x6E);
     AddTextPrinterParameterized(sSaveInfoWindowId, 2, gStringVar4, xOffset, yOffset, 0xFF, NULL);
 
     CopyWindowToVram(sSaveInfoWindowId, 2);


### PR DESCRIPTION
Bug caused because using the FR Font.

## Description
Fixes numbers x coordinate of play time text when saving the game.

## **Discord contact info**
Jaizu#4989